### PR TITLE
Update to use Labkey Java API in Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Labkey Dumper
 
-This project builds upon the [Labkey Client](https://github.com/chrismattmann/labkey-client) program to connect to a Labkey instance and then to dump out the Study objects from it into a JSON format. The JSON format looks like:
+This project builds upon the [Labkey Client](https://www.labkey.org/wiki/home/Documentation/page.view?name=javaAPI) API to connect to a Labkey instance and then to dump out the Study objects from it into a JSON format. The JSON format looks like:
 
 ```
 {"studies":[
@@ -28,11 +28,8 @@ This project builds upon the [Labkey Client](https://github.com/chrismattmann/la
 # Building this appilcation
 
 0. mkdir -p $HOME/src && cd $HOME/src
-1. git clone https://github.com/chrismattmann/labkey-client.git
-2. cd labkey-client && mvn install assembly:assembly
-3. cd ..
-4. git clone https://github.com/chrismattmann/labkey-dumper.git
-5. cd labkey-dumper && mvn install assembly:assembly
+1. git clone https://github.com/chrismattmann/labkey-dumper.git
+2. cd labkey-dumper && mvn install assembly:assembly
 
 All done!
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
                 <descriptors>
                     <descriptor>src/main/assembly/assembly.xml</descriptor>
                 </descriptors>
+                <archive>
+                  <manifest>
+                    <addClasspath>true</addClasspath>
+                    <mainClass>gov.nasa.jpl.celgene.labkey.LabkeyDumper</mainClass>
+                  </manifest>
+                </archive>
             </configuration>
           </plugin>     
         </plugins> 
@@ -48,6 +54,16 @@
       <groupId>net.sf.opencsv</groupId>
       <artifactId>opencsv</artifactId>
       <version>1.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.4</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,13 @@
   <dependencies>
     <dependency>
       <groupId>org.labkey</groupId>
-      <artifactId>labkey-client</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <artifactId>labkey-client-api</artifactId>
+      <version>0.1</version>
     </dependency>
-	<dependency>
-	    <groupId>org.apache.commons</groupId>
-	    <artifactId>commons-lang3</artifactId>
-	    <version>3.2</version>
-	</dependency>
-
-  
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,20 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.2</version>
     </dependency>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1</version>
+    </dependency> 
+    <dependency>
+      <groupId>net.sf.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>1.8</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Hi @chrismattmann please see update which means you don;t need to maintain Labkey remoteapi Java client in your GH repos. 
We can just push Labkey remoteapi Java API's to Maven Central when a new release comes out so that we are up-to-date.
Thanks 
